### PR TITLE
Fixed missing data warning not appearing in export summary

### DIFF
--- a/Core/Application/Common/Extensions/RemsDbContextExtensions.cs
+++ b/Core/Application/Common/Extensions/RemsDbContextExtensions.cs
@@ -81,7 +81,7 @@ namespace Rems.Application.Common.Extensions
 
             var values = traits ?? datas;
 
-            return values.Any() ? values.ToArray() : new double[] { };
+            return values.Any() ? values.ToArray() : null;
         }
 
         /// <summary>


### PR DESCRIPTION
The method which printed out a message was checking for a null value, not an empty array.

Resolves #96