### PR TITLE
Added import for SoilData table

### DIFF
--- a/Core/Application/CQRS/Met/InsertMetDataTableCommand.cs
+++ b/Core/Application/CQRS/Met/InsertMetDataTableCommand.cs
@@ -43,9 +43,7 @@ namespace Rems.Application.CQRS
             IEnumerable<MetData> convertRow(DataRow row)
             {
                 // Look for the station which sourced the data, create one if it isn't found
-                var station = _context.MetStations.FirstOrDefault(e => e.Name == row[0].ToString());
-
-                IncrementProgress();
+                var station = _context.MetStations.FirstOrDefault(e => e.Name == row[0].ToString());                
 
                 for (int i = 2; i < row.ItemArray.Length; i++)
                 {
@@ -63,6 +61,8 @@ namespace Rems.Application.CQRS
                         Value = value
                     };
                 }
+
+                IncrementProgress();
             }
 
             var datas = Table.Rows.Cast<DataRow>()

--- a/Core/Application/CQRS/PlotData/InsertPlotDataTableCommand.cs
+++ b/Core/Application/CQRS/PlotData/InsertPlotDataTableCommand.cs
@@ -79,11 +79,11 @@ namespace Rems.Application.CQRS
 
                 IncrementProgress();
 
-                for (int i = 4; i < row.ItemArray.Length; i++)
+                for (int i = Skip; i < row.ItemArray.Length; i++)
                 {
                     if (row[i] is DBNull || row[i] is "") continue;
 
-                    var trait = traits[i - 4];
+                    var trait = traits[i - Skip];
                     var value = Convert.ToDouble(row[i]);
 
                     var x = new { key = row[0].ToString(), col = row[1] };

--- a/Core/Application/CQRS/Soils/InsertSoilDataTableCommand.cs
+++ b/Core/Application/CQRS/Soils/InsertSoilDataTableCommand.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using Rems.Application.Common.Extensions;
+using Rems.Application.Common.Interfaces;
+using Rems.Domain.Entities;
+
+using Unit = MediatR.Unit;
+
+namespace Rems.Application.CQRS
+{
+    /// <summary>
+    /// Inserts a table of SoilData into the database
+    /// </summary>
+    public class InsertSoilDataTableCommand : ContextQuery<Unit>
+    {
+        /// <summary>
+        /// The source data
+        /// </summary>
+        public DataTable Table { get; set; }
+
+        /// <summary>
+        /// The number of skippable columns preceding trait columns in the table
+        /// </summary>
+        public int Skip { get; set; }
+
+        public string Type { get; set; }
+
+        public Action IncrementProgress { get; set; }
+
+        /// <inheritdoc/>
+        public class Handler : BaseHandler<InsertSoilDataTableCommand>
+        {
+            public Handler(IRemsDbContextFactory factory) : base(factory) { }
+        }
+
+        /// <inheritdoc/>
+        protected override Unit Run()
+        {
+            if (Skip < 0)
+                throw new Exception("You cannot skip a negative number of columns");
+
+            var traits = _context.GetTraitsFromColumns(Table, Skip, Type);
+
+            IEnumerable<SoilData> convertRow(DataRow row)
+            {
+                // Find all plots in the treatment
+                var plots = _context.Plots
+                        .Where(p => p.Treatment.Experiment.Name == row[0].ToString());
+
+                // The plot ids
+                var ids = row[1].ToString().Split(',').Select(i => Convert.ToInt32(i));
+
+                // If the treatment does not specify 'avg' plot data, filter based on the column
+                if (row[1].ToString().ToLower() != "avg")
+                    plots = plots.Where(p => ids.Contains(p.Column.GetValueOrDefault()));
+
+                IncrementProgress();
+
+                // For each plot specified in the PlotId column
+                foreach (var plot in plots)
+                {
+                    // Convert all values from the 6th column onwards into SoilLayerData entities
+                    for (int i = Skip; i < row.ItemArray.Length; i++)
+                    {
+                        if (row[i] is DBNull || row[i] is "") continue;
+
+                        var value = Convert.ToDouble(row[i]);
+                        yield return new SoilData()
+                        {
+                            PlotId = plot.PlotId,
+                            TraitId = traits[i - Skip].TraitId,
+                            Date = Convert.ToDateTime(row[2]),
+                            Value = value
+                        };
+                    }
+                }
+            }
+
+            var datas = Table.Rows.Cast<DataRow>()
+                .SelectMany(r => convertRow(r))
+                .Distinct()
+                .ToArray();
+
+            if (_context.SoilLayerDatas.Any())
+                datas = datas.Except(_context.SoilDatas, new SoilDataComparer()).ToArray();
+
+            _context.AttachRange(datas.ToArray());
+            _context.SaveChanges();
+
+            return Unit.Value;
+        }
+        
+    }
+
+    internal class SoilDataComparer : IEqualityComparer<SoilData>
+    {
+        public bool Equals(SoilData x, SoilData y)
+        {
+            return x.Date == y.Date
+                && x.TraitId == y.TraitId
+                && x.PlotId == y.PlotId;
+        }
+
+        public int GetHashCode(SoilData obj)
+        {
+            var a = obj.Date.GetHashCode();
+
+            return a ^ obj.TraitId ^ obj.PlotId;
+        }
+    }
+}

--- a/Core/Application/Common/Extensions/RemsDbContextExtensions.cs
+++ b/Core/Application/Common/Extensions/RemsDbContextExtensions.cs
@@ -222,5 +222,20 @@ namespace Rems.Application.Common.Extensions
             else
                 set.Attach(data);
         }
+
+        internal static IEnumerable<Plot> FindPlots(this IRemsDbContext context, object content, Experiment experiment)
+        {
+            // Find all the plots in the experiment
+            var plots = context.Plots.Where(p => p.Treatment.Experiment == experiment);
+
+            var text = content.ToString().ToLower();
+
+            if (text == "all" || text == "avg")
+                return plots;
+
+            var ids = text.Split(',').Select(i => Convert.ToInt32(i));
+            
+            return plots.Where(p => ids.Contains(p.Column.GetValueOrDefault()));
+        }
     }
 }

--- a/Infrastructure/Infrastructure/ProgressTrackers/ExcelImporter.cs
+++ b/Infrastructure/Infrastructure/ProgressTrackers/ExcelImporter.cs
@@ -120,6 +120,16 @@ namespace Rems.Infrastructure.Excel
                     };
                     break;
 
+                case "SoilData":
+                    command = new InsertSoilDataTableCommand
+                    {
+                        Table = table,
+                        Skip = 3,
+                        Type = "Soil",
+                        IncrementProgress = OnIncrementProgress
+                    };
+                    break;
+
                 case "Soils":
                     command = new InsertSoilTableCommand
                     {


### PR DESCRIPTION
Working on #103 and #57 

None of the sorghum data had a SoilData table with values, so an import option had not been created yet.