### PR TITLE
Create new now overwrites existing files

### DIFF
--- a/Presentation/WindowsClient/Controls/HomeScreen.cs
+++ b/Presentation/WindowsClient/Controls/HomeScreen.cs
@@ -97,7 +97,10 @@ namespace WindowsClient.Controls
 
             // If overwriting a .db, remove the old session
             if (Sessions.Find(s => s.DB == file) is Session S)
+            {
                 Sessions.Remove(S);
+                File.Delete(file);
+            }
 
             // Change to the new session
             await ChangeSession(session);
@@ -179,17 +182,16 @@ namespace WindowsClient.Controls
         /// </summary>
         private async void OnCreateClick(object sender, EventArgs e)
         {
-            using (var save = new SaveFileDialog())
-            {
-                save.InitialDirectory = Manager.ImportFolder;
-                save.AddExtension = true;
-                save.Filter = "SQLite (*.db)|*.db";
-                save.RestoreDirectory = true;
+            using var save = new SaveFileDialog();
 
-                if (save.ShowDialog() != DialogResult.OK) return;
+            save.InitialDirectory = Manager.ImportFolder;
+            save.AddExtension = true;
+            save.Filter = "SQLite (*.db)|*.db";
+            save.RestoreDirectory = true;
 
-                await CreateSession(save.FileName);
-            }
+            if (save.ShowDialog() != DialogResult.OK) return;
+
+            await CreateSession(save.FileName);
         }
 
         /// <summary>

--- a/Presentation/WindowsClient/Models/Session.cs
+++ b/Presentation/WindowsClient/Models/Session.cs
@@ -16,18 +16,6 @@ namespace WindowsClient.Models
         /// </summary>
         public string DB { get; set; }
 
-        [JsonIgnore]
-        public TabPage Experiments { get; } = new TabPage("Experiment details");
-
-        [JsonIgnore]
-        public ExperimentDetailer Detailer { get; } = new ExperimentDetailer();
-
-        public Session()
-        {
-            Detailer.Dock = DockStyle.Fill;
-            Experiments.Controls.Add(Detailer);
-        }
-
         /// <inheritdoc/>
         public override string ToString() => Path.GetFileName(DB);
     }


### PR DESCRIPTION
Resolves #94

If the user chooses the name of an existing file when creating a new .db, that file is now correctly overwritten.