### PR TITLE
Corrects the experiments table import

### DIFF
--- a/Core/Application/CQRS/Experiments/InsertExperimentsTableCommand.cs
+++ b/Core/Application/CQRS/Experiments/InsertExperimentsTableCommand.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+using Rems.Application.Common;
+using Rems.Application.Common.Interfaces;
+using Rems.Domain.Entities;
+
+using Unit = MediatR.Unit;
+
+namespace Rems.Application.CQRS
+{
+    /// <summary>
+    /// Insert a table of MetData into the database
+    /// </summary>
+    public class InsertExperimentsTableCommand : ContextQuery<Unit>
+    {
+        /// <summary>
+        /// The source table
+        /// </summary>
+        public DataTable Table { get; set; }     
+
+        /// <inheritdoc/>
+        public class Handler : BaseHandler<InsertExperimentsTableCommand>
+        {
+            public Handler(IRemsDbContextFactory factory) : base(factory) { }
+        }
+
+        /// <inheritdoc/>
+        protected override Unit Run()
+        {
+            Experiment convertRow(DataRow row)
+            {
+                var crop = _context.Crops.FirstOrDefault(c => c.Name == Convert.ToString(row["Crop"]));
+
+                var site = _context.Sites.FirstOrDefault(s => s.Name == Convert.ToString(row["SiteName"]));
+                var field = site.Fields.FirstOrDefault(f => f.Name == Convert.ToString(row["Field"]));
+
+                var met = _context.MetStations.FirstOrDefault(s => s.Name == Convert.ToString(row["MetStation"]));
+                
+                var result = new Experiment
+                {
+                    Name = Convert.ToString(row["Name"]),
+                    Description = Convert.ToString(row["Description"]),
+                    Crop = crop,
+                    Field = field,
+                    BeginDate = Convert.ToDateTime(row["BeginDate"]),
+                    EndDate = Convert.ToDateTime(row["EndDate"]),
+                    MetStation = met,
+                    Design = Convert.ToString(row["Design"]),
+                    Repetitions = Convert.ToInt32(row["Repetitions"]),
+                    Rating = Convert.ToInt32(row["Rating"]),
+                    Notes = Convert.ToString(row["Notes"])
+            };
+
+                Progress.Increment(1);
+
+                return result;
+            }
+
+            var datas = Table.Rows.Cast<DataRow>()
+                .Select(r => convertRow(r))
+                .Distinct();
+
+            if (_context.Experiments.Any())
+                datas = datas.Except(_context.Experiments, new ExperimentComparer());
+
+            _context.AddRange(datas.ToArray());
+            _context.SaveChanges();
+
+            return Unit.Value;
+        }
+        
+    }
+
+    /// <summary>
+    /// Compares MetData entities based on the values of some properties
+    /// </summary>
+    internal class ExperimentComparer : IEqualityComparer<Experiment>
+    {
+        public bool Equals(Experiment x, Experiment y)
+        {
+            return x.Name == y.Name
+                && x.BeginDate == y.BeginDate
+                && x.EndDate == y.EndDate;
+        }
+
+        public int GetHashCode(Experiment obj)
+        {
+            var nHash = obj.Name.GetHashCode();
+            var bHash = obj.BeginDate.GetHashCode();
+            var eHash = obj.EndDate.GetHashCode();
+
+            return Utilities.GenerateHash(nHash, bHash, eHash);
+        }
+    }
+}

--- a/Core/Application/Common/Extensions/DataExtensions.cs
+++ b/Core/Application/Common/Extensions/DataExtensions.cs
@@ -225,6 +225,7 @@ namespace Rems.Application.Common.Extensions
             {"amp", "Amplitude" },
             {"tav", "TemperatureAverage" },
             {"PlotID", "Plot" },
+            {"Number of Reps", "Repetitions"},
             {"Reps", "Repetitions" },
             {"Rep", "Repetition" },
             {"RepNo", "Repetition" },

--- a/Infrastructure/Infrastructure/ProgressTrackers/ExcelImporter.cs
+++ b/Infrastructure/Infrastructure/ProgressTrackers/ExcelImporter.cs
@@ -70,9 +70,17 @@ namespace Rems.Infrastructure.Excel
             switch (table.TableName)
             {
                 case "Design":
-                    await InvokeQuery(new InsertDesignsCommand() { Table = table });
-                    command = new InsertPlotsCommand() 
+                    await InvokeQuery(new InsertDesignsCommand { Table = table });
+                    command = new InsertPlotsCommand
                     { 
+                        Table = table,
+                        Progress = Reporter
+                    };
+                    break;
+
+                case "Experiments":
+                    command = new InsertExperimentsTableCommand
+                    {
                         Table = table,
                         Progress = Reporter
                     };
@@ -80,7 +88,7 @@ namespace Rems.Infrastructure.Excel
 
                 case "HarvestData":
                 case "PlotData":
-                    command = new InsertPlotDataTableCommand()
+                    command = new InsertPlotDataTableCommand
                     {
                         Table = table,
                         Skip = 4,
@@ -90,7 +98,7 @@ namespace Rems.Infrastructure.Excel
                     break;
 
                 case "MetData":
-                    command = new InsertMetDataTableCommand()
+                    command = new InsertMetDataTableCommand
                     {
                         Table = table,
                         Skip = 2,
@@ -100,7 +108,7 @@ namespace Rems.Infrastructure.Excel
                     break;
 
                 case "SoilLayerData":
-                    command = new InsertSoilLayerTableCommand()
+                    command = new InsertSoilLayerTableCommand
                     {
                         Table = table,
                         Skip = 5,
@@ -112,7 +120,7 @@ namespace Rems.Infrastructure.Excel
                 case "Irrigation":
                 case "Fertilization":
                 case "Tillage":
-                    command = new InsertOperationsTableCommand() 
+                    command = new InsertOperationsTableCommand
                     { 
                         Table = table, 
                         Type = type,
@@ -141,7 +149,7 @@ namespace Rems.Infrastructure.Excel
 
                 case "SoilLayer":
                 case "SoilLayers":
-                    command = new InsertSoilLayerTraitsCommand()
+                    command = new InsertSoilLayerTraitsCommand
                     {
                         Table = table,
                         Type = type,
@@ -150,7 +158,7 @@ namespace Rems.Infrastructure.Excel
                     break;
 
                 default:
-                    command = new InsertTableCommand()
+                    command = new InsertTableCommand
                     { 
                         Table = table,
                         Type = type,

--- a/Presentation/WindowsClient/Models/Nodes/ColumnNode.cs
+++ b/Presentation/WindowsClient/Models/Nodes/ColumnNode.cs
@@ -86,6 +86,7 @@ namespace WindowsClient.Models
         {
             Text = info.Name;
             Excel.State["Info"] = info;
+            Excel.Data.ColumnName = info.Name;
 
             InvokeUpdated();
         }

--- a/Presentation/WindowsClient/Models/Nodes/DataNode.cs
+++ b/Presentation/WindowsClient/Models/Nodes/DataNode.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Drawing;
+using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace WindowsClient.Models
@@ -34,9 +35,12 @@ namespace WindowsClient.Models
         /// <summary>
         /// Begins editing the node label
         /// </summary>
-        protected void Rename(object sender, EventArgs args)
+        protected async void Rename(object sender, EventArgs args)
         {
             BeginEdit();
+
+            await Task.Run(() => { while (IsEditing) { } });
+
             InvokeUpdated();
         }
 


### PR DESCRIPTION
Previously the site name was not considered in the import, allowing for potential conflict between fields of the same name on different sites. Experiments now has a custom table importer that correctly searches for the field and site.

Resolves #146