### PR TITLE
Added handling for 'Design' table in the import

### DIFF
--- a/Core/Application/CQRS/ExcelDataQuery.cs
+++ b/Core/Application/CQRS/ExcelDataQuery.cs
@@ -13,14 +13,14 @@ namespace Rems.Application.CQRS
     /// <summary>
     /// Return a collection of all experiments paired by ID and Name
     /// </summary>
-    public class InformationQuery : ContextQuery<Dictionary<ExcelTable, ExcelColumn[]>>
+    public class ExcelDataQuery : ContextQuery<Dictionary<ExcelTable, ExcelColumn[]>>
     {
         public DataSet Data { get; set; }
 
         public string Format { get; set; }
 
         /// <inheritdoc/>
-        public class Handler : BaseHandler<InformationQuery>
+        public class Handler : BaseHandler<ExcelDataQuery>
         {
             public Handler(IRemsDbContextFactory factory) : base(factory) { }
         }

--- a/Core/Application/CQRS/Factors/AddFactorCommand.cs
+++ b/Core/Application/CQRS/Factors/AddFactorCommand.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq;
+using Rems.Application.Common.Interfaces;
+using Rems.Domain.Entities;
+using Unit = MediatR.Unit;
+
+namespace Rems.Application.CQRS
+{
+    /// <summary>
+    /// Generates an APSIM Permutation model for an experiment
+    /// </summary>
+    public class AddFactorCommand : ContextQuery<Unit>
+    { 
+        /// <summary>
+        /// The name of the factor to look for
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <inheritdoc/>
+        public class Handler : BaseHandler<AddFactorCommand>
+        {
+            public Handler(IRemsDbContextFactory factory) : base(factory) { }
+        }
+
+        /// <inheritdoc/>
+        protected override Unit Run()
+        {
+            var factor = new Factor { Name = Name };
+            _context.Add(factor);
+            _context.SaveChanges();
+
+            return Unit.Value;
+        }
+    }
+}

--- a/Core/Application/CQRS/Factors/IsFactorQuery.cs
+++ b/Core/Application/CQRS/Factors/IsFactorQuery.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Linq;
+using Rems.Application.Common.Interfaces;
+
+namespace Rems.Application.CQRS
+{
+    /// <summary>
+    /// Generates an APSIM Permutation model for an experiment
+    /// </summary>
+    public class IsFactorQuery : ContextQuery<bool>
+    { 
+        /// <summary>
+        /// The name of the factor to look for
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <inheritdoc/>
+        public class Handler : BaseHandler<IsFactorQuery>
+        {
+            public Handler(IRemsDbContextFactory factory) : base(factory) { }
+        }
+
+        /// <inheritdoc/>
+        protected override bool Run() => _context.Factors.Any(f => f.Name == Name);
+    }
+}

--- a/Core/Domain/Entities/Sowing.cs
+++ b/Core/Domain/Entities/Sowing.cs
@@ -3,7 +3,7 @@ using System;
 
 namespace Rems.Domain.Entities
 {
-    [ExcelFormat("Information", true, "Sowing", "Planting")]
+    [ExcelFormat("Experiments", true, "Sowing", "Planting")]
     public class Sowing : IEntity
     {
         public int SowingId { get; set; }

--- a/Core/Domain/Entities/Tillage.cs
+++ b/Core/Domain/Entities/Tillage.cs
@@ -5,7 +5,7 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace Rems.Domain.Entities
 {
-    [ExcelFormat("Information", false, "Tillage")]
+    [ExcelFormat("Experiments", false, "Tillage")]
     public class Tillage : IEntity
     {
         public Tillage()

--- a/Core/Domain/Entities/Tillage.cs
+++ b/Core/Domain/Entities/Tillage.cs
@@ -39,6 +39,5 @@ namespace Rems.Domain.Entities
         public virtual Treatment Treatment { get; set; }
         
         public virtual ICollection<TillageInfo> TillageInfo { get; set; }
-
     }
 }

--- a/Presentation/WindowsClient/Controls/Experiments/ExperimentControl.cs
+++ b/Presentation/WindowsClient/Controls/Experiments/ExperimentControl.cs
@@ -30,7 +30,6 @@ namespace WindowsClient.Controls
 
         public ExperimentNode(string text) : base(text)
         {
-            //Nodes.Add(design);
             Nodes.Add(operations);
             Nodes.Add(crop);
             Nodes.Add(soil);
@@ -38,9 +37,6 @@ namespace WindowsClient.Controls
 
         public Task<TabControl> GetSelectedControl()
         {
-            //if (design.IsSelected)
-            //    return design.Create(ID);
-
             if (operations.IsSelected)
                 return operations.Create(ID);
 

--- a/Presentation/WindowsClient/Controls/Importer.cs
+++ b/Presentation/WindowsClient/Controls/Importer.cs
@@ -95,7 +95,7 @@ namespace WindowsClient.Controls
 
         private async Task GenerateNodes(DataSet data, string format)
         {
-            var query = new InformationQuery { Data = data, Format = format };
+            var query = new ExcelDataQuery { Data = data, Format = format };
             var tables = await QueryManager.Request(query);
 
             foreach (var pair in tables)
@@ -133,10 +133,10 @@ namespace WindowsClient.Controls
             foreach (var col in unknowns)
             {
                 var excel = new ExcelColumn { Data = col };
-                var cn = new TraitNode(excel);
-                await cn.CheckForTrait();
+                var cn = new TraitNode(excel);           
 
                 node.Traits.Nodes.Add(cn);
+                await cn.Initialise();
             }
 
             node.Refresh();
@@ -167,10 +167,6 @@ namespace WindowsClient.Controls
                 await CleanTable(table);
 
                 table.ConvertExperiments();
-
-                //var node = await CreateTableNode(table);
-
-                //dataTree.Nodes.Add(node);
             }
         }
 

--- a/Presentation/WindowsClient/Models/Nodes/TableNode.cs
+++ b/Presentation/WindowsClient/Models/Nodes/TableNode.cs
@@ -49,19 +49,19 @@ namespace WindowsClient.Models
 
             Items.Add(ignore);
 
-            Traits.Items.Add(new ToolStripMenuItem("Add all as Traits", null, AddTraits));
+            Traits.Items.Add(new ToolStripMenuItem("Add all as Traits", null, AddAllNodes));
             Traits.Items.Add(new ToolStripMenuItem("Toggle ignore", null, ToggleIgnoreAll));
         }
 
         /// <summary>
         /// Adds a trait to the database for every invalid child node
         /// </summary>
-        public async void AddTraits(object sender, EventArgs args)
+        public async void AddAllNodes(object sender, EventArgs args)
         {
             var nodes = TreeView.SelectedNode.Nodes.OfType<TraitNode>();
             foreach (var node in nodes)
                 if (!node.Valid)
-                    await node.AddTrait();
+                    await node.Add.Invoke();
 
             Refresh();
         }

--- a/Presentation/WindowsClient/Models/Nodes/TraitNode.cs
+++ b/Presentation/WindowsClient/Models/Nodes/TraitNode.cs
@@ -14,6 +14,8 @@ namespace WindowsClient.Models
 
         private bool traitExists;
 
+        public Func<Task> Add;
+
         public override string Key
         {
             get
@@ -28,18 +30,12 @@ namespace WindowsClient.Models
         public TraitNode(ExcelColumn excel) : base(excel)
         {
             var ignore = new ToolStripMenuItem("Ignore", null, (s, e) => ToggleIgnore());
-            var addtrait = new ToolStripMenuItem("Add as trait", null, AddTraitClicked);
-            
             Items.Add(ignore);
-            Items.Add(addtrait);
-        }
 
-        /// <summary>
-        /// Adds a trait to the database representing the current node
-        /// </summary>
-        public async void AddTraitClicked(object sender, EventArgs args)
-        {
-            await AddTrait();
+            EventHandler handler = async (s, e) => await Add.Invoke();
+            var add = new ToolStripMenuItem("Add as trait", null, handler);            
+
+            Items.Add(add);            
         }
 
         public async Task AddTrait()
@@ -59,11 +55,33 @@ namespace WindowsClient.Models
             Root.Refresh();
         }
 
-        /// <summary>
-        /// Tests if the column is referring to a known database trait
-        /// </summary>
-        public async Task CheckForTrait()
+        public async Task AddFactor()
         {
+            if (Excel.Ignore)
+                return;
+
+            var query = new AddFactorCommand { Name = Excel.Data.ColumnName };
+            await QueryManager.Request(query);
+
+            traitExists = true;
+            Root.Refresh();
+        }
+
+        /// <summary>
+        /// Initialisation that can only be done after being added to a parent node
+        /// </summary>
+        public async Task Initialise()
+        {
+            if (Excel.Data.Table.TableName == "Design")
+            {
+                Parent.Text = "Factors";
+                Add = AddFactor;
+                Items[1].Text = "Add as factor";
+                Parent.ContextMenuStrip.Items[0].Text = "Add all as factors";
+            }
+            else
+                Add = AddTrait;
+
             if (Excel.Data is null)
             {
                 traitExists = false;
@@ -73,24 +91,26 @@ namespace WindowsClient.Models
             // Test if the trait is in the database
             bool inDB = await QueryManager.Request(new TraitExistsQuery() { Name = Excel.Data.ColumnName });
 
-            // Test if the trait is in the excel data
-            bool inExcel()
-            {
-                // Is there a traits table
-                if (Excel.Data.Table?.DataSet?.Tables["Traits"] is not DataTable traits)
-                    return false;
-
-                // Is there a column with trait names
-                if (traits.Columns["Name"] is not DataColumn name)
-                    return false;
-
-                var rows = traits.Rows.Cast<DataRow>();
-                var trait = Excel.Data.ColumnName.ToLower();
-
-                return rows.Any(r => r[name].ToString().ToLower() == trait);
-            };
-
-            traitExists = inDB || inExcel();
+            traitExists = inDB || InExcel() || await IsFactor();
         }
+
+        private bool InExcel()
+        {
+            // Is there a traits table
+            if (Excel.Data.Table?.DataSet?.Tables["Traits"] is not DataTable traits)
+                return false;
+
+            // Is there a column with trait names
+            if (traits.Columns["Name"] is not DataColumn name)
+                return false;
+
+            var rows = traits.Rows.Cast<DataRow>();
+            var trait = Excel.Data.ColumnName.ToLower();
+
+            return rows.Any(r => r[name].ToString().ToLower() == trait);
+        }
+
+        private async Task<bool> IsFactor()
+            => await QueryManager.Request(new IsFactorQuery { Name = Excel.Data.ColumnName });
     }
 }


### PR DESCRIPTION
When a trait node is initialised it now checks if its parent is the 'Design' table - the enforcement of expected tables guarantees the existence of a design table appearing at some point in the import process.

If it is a child of the design table, a traitnode then switches out what the 'Add' function does, to include the data as a factor instead of a trait. The UI is updated accordingly.

Resolves #153 